### PR TITLE
Add Smart Garden Planner example

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,16 @@ python examples/costorm_examples/run_costorm_gpt.py \
     --retriever bing
 ```
 
+### Smart Garden Planner example
+
+The `examples/smart_garden_planner` folder contains a small demo that
+generates plant recommendations and watering schedules based on simple
+climate inputs.
+
+```bash
+python examples/smart_garden_planner/garden_planner.py --climate temperate --sunlight "full sun" --soil loamy --rainfall 5
+```
+
 
 ## Customization of the Pipeline
 

--- a/README.md
+++ b/README.md
@@ -273,7 +273,13 @@ python examples/costorm_examples/run_costorm_gpt.py \
 
 The `examples/smart_garden_planner` folder contains a small demo that
 generates plant recommendations and watering schedules based on simple
-climate inputs.
+climate inputs. It includes a Streamlit interface for quick exploration.
+
+```bash
+streamlit run examples/smart_garden_planner/web_app.py
+```
+
+You can also run the command line tool:
 
 ```bash
 python examples/smart_garden_planner/garden_planner.py --climate temperate --sunlight "full sun" --soil loamy --rainfall 5

--- a/examples/smart_garden_planner/README.md
+++ b/examples/smart_garden_planner/README.md
@@ -1,11 +1,19 @@
 # Smart Garden Planner Example
 
-This example demonstrates a basic garden planning tool that recommends plants and watering schedules based on climate and rainfall information. It uses a small sample plant database (`plant_data.json`).
+This example demonstrates a small web-based garden planner that recommends plants and watering schedules based on climate and rainfall information. It uses a sample plant database (`plant_data.json`).
 
 ## Usage
+
+Launch the Streamlit interface:
+
+```bash
+streamlit run web_app.py
+```
+
+For command line usage you can still run:
 
 ```bash
 python garden_planner.py --climate temperate --sunlight "full sun" --soil loamy --rainfall 5
 ```
 
-The script will output recommended plants and a simple watering schedule adjusted for weekly rainfall.
+Both interfaces will display recommended plants and a simple watering schedule adjusted for weekly rainfall.

--- a/examples/smart_garden_planner/README.md
+++ b/examples/smart_garden_planner/README.md
@@ -1,0 +1,11 @@
+# Smart Garden Planner Example
+
+This example demonstrates a basic garden planning tool that recommends plants and watering schedules based on climate and rainfall information. It uses a small sample plant database (`plant_data.json`).
+
+## Usage
+
+```bash
+python garden_planner.py --climate temperate --sunlight "full sun" --soil loamy --rainfall 5
+```
+
+The script will output recommended plants and a simple watering schedule adjusted for weekly rainfall.

--- a/examples/smart_garden_planner/garden_planner.py
+++ b/examples/smart_garden_planner/garden_planner.py
@@ -1,0 +1,68 @@
+import argparse
+import json
+from pathlib import Path
+
+
+PLANT_DATA = Path(__file__).parent / "plant_data.json"
+
+
+def load_plants():
+    with open(PLANT_DATA, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def recommend_plants(plants, climate, sunlight, soil):
+    """Return plants matching climate, sunlight, and soil preferences."""
+    matches = []
+    for plant in plants:
+        if climate and climate not in plant["climate"]:
+            continue
+        if soil and plant["soil"] != soil:
+            continue
+        if sunlight and not plant["sunlight"].startswith(sunlight.split()[0]):
+            continue
+        matches.append(plant)
+    return matches
+
+
+def watering_schedule(plant, rainfall):
+    required = max(plant["water_mm_per_week"] - rainfall, 0)
+    if required == 0:
+        times = 0
+    elif required < 10:
+        times = 1
+    elif required < 20:
+        times = 2
+    else:
+        times = 3
+    return required, times
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple garden planner")
+    parser.add_argument("--climate", required=True, help="Local climate zone")
+    parser.add_argument("--sunlight", required=True, help="Sunlight exposure")
+    parser.add_argument("--soil", required=True, help="Soil type")
+    parser.add_argument(
+        "--rainfall",
+        type=float,
+        default=0.0,
+        help="Weekly rainfall in millimeters",
+    )
+    args = parser.parse_args()
+
+    plants = load_plants()
+    matches = recommend_plants(plants, args.climate, args.sunlight, args.soil)
+
+    if not matches:
+        print("No matching plants found for the specified conditions.")
+        return
+
+    print("Recommended plants:")
+    for plant in matches:
+        required, times = watering_schedule(plant, args.rainfall)
+        print(f"- {plant['name']}: water {required}mm/week ({times}x)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/smart_garden_planner/garden_planner.py
+++ b/examples/smart_garden_planner/garden_planner.py
@@ -1,3 +1,5 @@
+"""Utility functions for recommending plants and watering schedules."""
+
 import argparse
 import json
 from pathlib import Path
@@ -26,6 +28,7 @@ def recommend_plants(plants, climate, sunlight, soil):
 
 
 def watering_schedule(plant, rainfall):
+    """Return weekly water requirement and number of waterings."""
     required = max(plant["water_mm_per_week"] - rainfall, 0)
     if required == 0:
         times = 0
@@ -36,6 +39,14 @@ def watering_schedule(plant, rainfall):
     else:
         times = 3
     return required, times
+
+
+def watering_string(plant, rainfall):
+    required, times = watering_schedule(plant, rainfall)
+    if times == 0:
+        return "no extra watering needed"
+    plural = "time" if times == 1 else "times"
+    return f"water {required}mm/week ({times} {plural})"
 
 
 def main():

--- a/examples/smart_garden_planner/plant_data.json
+++ b/examples/smart_garden_planner/plant_data.json
@@ -19,5 +19,19 @@
         "sunlight": "full sun",
         "soil": "well-drained",
         "water_mm_per_week": 15
+    },
+    {
+        "name": "Carrot",
+        "climate": ["cool", "temperate"],
+        "sunlight": "full sun",
+        "soil": "loamy",
+        "water_mm_per_week": 20
+    },
+    {
+        "name": "Rosemary",
+        "climate": ["temperate", "warm"],
+        "sunlight": "full sun",
+        "soil": "well-drained",
+        "water_mm_per_week": 10
     }
 ]

--- a/examples/smart_garden_planner/plant_data.json
+++ b/examples/smart_garden_planner/plant_data.json
@@ -1,0 +1,23 @@
+[
+    {
+        "name": "Tomato",
+        "climate": ["temperate", "warm"],
+        "sunlight": "full sun",
+        "soil": "loamy",
+        "water_mm_per_week": 25
+    },
+    {
+        "name": "Lettuce",
+        "climate": ["cool", "temperate"],
+        "sunlight": "partial shade",
+        "soil": "loamy",
+        "water_mm_per_week": 20
+    },
+    {
+        "name": "Basil",
+        "climate": ["warm", "tropical"],
+        "sunlight": "full sun",
+        "soil": "well-drained",
+        "water_mm_per_week": 15
+    }
+]

--- a/examples/smart_garden_planner/web_app.py
+++ b/examples/smart_garden_planner/web_app.py
@@ -1,0 +1,33 @@
+import streamlit as st
+
+from garden_planner import load_plants, recommend_plants, watering_string
+
+st.set_page_config(page_title="Smart Garden Planner")
+st.title("Smart Garden Planner")
+
+plants = load_plants()
+
+# Gather options
+climate_options = sorted({c for p in plants for c in p["climate"]})
+soil_options = sorted({p["soil"] for p in plants})
+sun_options = sorted({p["sunlight"] for p in plants})
+
+with st.sidebar:
+    st.header("Garden Conditions")
+    climate = st.selectbox("Climate", climate_options)
+    sunlight = st.selectbox("Sunlight", sun_options)
+    soil = st.selectbox("Soil", soil_options)
+    rainfall = st.slider("Rainfall this week (mm)", 0, 40, 0)
+
+matches = recommend_plants(plants, climate, sunlight, soil)
+
+if not matches:
+    st.warning("No matching plants found.")
+else:
+    st.subheader("Recommended Plants")
+    for plant in matches:
+        st.markdown(f"### {plant['name']}")
+        st.write(f"Sunlight: {plant['sunlight']}  ")
+        st.write(f"Soil: {plant['soil']}  ")
+        st.write(watering_string(plant, rainfall))
+        st.markdown("---")

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ langchain-qdrant
 numpy==1.26.4
 litellm==1.59.3
 diskcache
+streamlit


### PR DESCRIPTION
## Summary
- add simple `smart_garden_planner` example with sample plant data
- show how to run the planner in README

## Testing
- `pre-commit run --files README.md examples/smart_garden_planner/garden_planner.py examples/smart_garden_planner/plant_data.json examples/smart_garden_planner/README.md`
- `python examples/smart_garden_planner/garden_planner.py --climate temperate --sunlight "full sun" --soil loamy --rainfall 5`


------
https://chatgpt.com/codex/tasks/task_e_687827ebb96483229c101ac7f9000280